### PR TITLE
keep transform from failing when multiple cwe elements present

### DIFF
--- a/src/main/resources/dependencycheck_to_pmd.xsl
+++ b/src/main/resources/dependencycheck_to_pmd.xsl
@@ -21,7 +21,7 @@
                             <xsl:attribute name="ruleset">
                                 <xsl:value-of select="@source"/>
                             </xsl:attribute>
-                            <xsl:value-of select='concat("Filename: ",../../b:fileName," | Reference: ",b:name," | CVSS Score: ",b:cvssV3/b:baseScore," | Category: ",b:cwes/b:cwe," | ",b:description)'/>
+                            <xsl:value-of select='concat("Filename: ",../../b:fileName," | Reference: ",b:name," | CVSS Score: ",b:cvssV3/b:baseScore," | Category: ",b:cwes/b:cwe[1]," | ",b:description)'/>
                         </violation>
                     </xsl:for-each>
                 </a:file>


### PR DESCRIPTION
Hi, I tried your approach, but found that in our project the output of the scan had some `<cwes>` tags with multiple `<cwe>` children, which makes the transform fail with the following error:
```
net.sf.saxon.trans.DynamicError: A sequence of more than one item is not allowed as the 8th argument of concat()
```
This PR tries to fix this by always selecting the first child.